### PR TITLE
Fix for Duux Whisper Flex 2

### DIFF
--- a/drivers/whisper-flex-2/device.js
+++ b/drivers/whisper-flex-2/device.js
@@ -279,10 +279,11 @@ module.exports = class WhisperFlexDevice extends Homey.Device {
           const battery = status.batlvl;
           if (battery === 0) {
             await this.removeCapability('measure_battery');
+          } else {
+            await this.setCapabilityValue('measure_battery', battery).catch(err => {
+              this.error('Error setting measure_battery capability:', err);
+            });
           }
-          await this.setCapabilityValue('measure_battery', battery).catch(err => {
-            this.error('Error setting measure_battery capability:', err);
-          });
         }
 
         // Log if device is in error state


### PR DESCRIPTION
Previously gave the following error when using a Duux Whisper Flex 2 without a battery connected ( i do not own a battery so i did not tested this with a battery)

```bash
2026-06-22T19:58:56.094Z [err] [ManagerDrivers] [Driver:whisper-flex-2] [Device:4323e049-e9b2-4a0d-b837-3304fa5b4136] Error setting measure_battery capability: Error: Invalid Capability: measure_battery
    at Remote Process
    at HomeyClient.emit (/node_modules/@athombv/homey-apps-sdk-v3/lib/HomeyClient.js:44:23)
    at Object.emit (/node_modules/@athombv/homey-apps-sdk-v3/manager/drivers.js:78:54)
    at Object.emit (/node_modules/@athombv/homey-apps-sdk-v3/lib/Driver.js:126:50)
    at /node_modules/@athombv/homey-apps-sdk-v3/lib/Device.js:592:10
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at WhisperFlexDevice.setCapabilityValue (/node_modules/@athombv/homey-apps-sdk-v3/lib/Device.js:574:23)
    at WhisperFlexDevice.pollDeviceStatus (/app/drivers/whisper-flex-2/device.js:283:22)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
  statusCode: 404
}
```